### PR TITLE
network.ymlのoutputsの追記

### DIFF
--- a/cloudformation/lecture10-network.yml
+++ b/cloudformation/lecture10-network.yml
@@ -193,11 +193,11 @@ Outputs:
 
   
   PrivateSubnet1:
-    Value: !Ref  PublicSubnet1  
+    Value: !Ref  PrivateSubnet1  
     Export:
       Name: !Sub ${NameBase}-PrivateSubnet1id
 
   PrivateSubnet2:
-    Value: !Ref  PublicSubnet2  
+    Value: !Ref  PrivateSubnet2  
     Export:
       Name: !Sub ${NameBase}-PrivateSubnet2id

--- a/cloudformation/lecture10-network.yml
+++ b/cloudformation/lecture10-network.yml
@@ -173,3 +173,31 @@ Resources:
     Properties:
       SubnetId: !Ref PrivateSubnet2
       RouteTableId: !Ref PrivateRouteTable
+
+Outputs:
+  VPC:
+    Value: !Ref  TestVPC
+    Export:
+      Name: !Sub  ${NameBase}-VPCid
+
+  
+  PublicSubnet1:
+    Value: !Ref  PublicSubnet1  
+    Export:
+      Name: !Sub ${NameBase}-PublicSubnet1id
+
+  PublicSubnet2:
+    Value: !Ref  PublicSubnet2  
+    Export:
+      Name: !Sub ${NameBase}-PublicSubnet2id
+
+  
+  PrivateSubnet1:
+    Value: !Ref  PublicSubnet1  
+    Export:
+      Name: !Sub ${NameBase}-PrivateSubnet1id
+
+  PrivateSubnet2:
+    Value: !Ref  PublicSubnet2  
+    Export:
+      Name: !Sub ${NameBase}-PrivateSubnet2id


### PR DESCRIPTION
お世話になります。
第12回課題にて、circleciのサンプルコンフィグを自分の課題用レポジトリ「tushima-raisetech-task」にてブランチgit-lecture12にて動作させました！
その際、動作確認のため、自分の課題用レポジトリのcloudformationディレクトリ下に、cloudformationテンプレートlecture10-network.ymlを追加しました！
第12回課題提出の際にプルリクエストし、コメント頂きcloudformationディレクトリ下のテンプレートのEOFエラー検知の対応をしました！
その際に、誤ってlecture10-network.ymlのoutputの記述が抜けたままのテンプレートになっていまして、私の確認不足で気づかずマージしてしまいました。
outputsの記述を追加しましたので、再度テンプレートにEOFエラーがないか確認いただき、問題なければoutputs記述分もマージさせていただければと思います！
お手数をおかけいたしますが、再度ご確認よろしくお願いします！